### PR TITLE
Add a newline at the end of a log entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Stackdriver-compatible tracing Subscriber"
 keywords = ["tracing", "stackdriver", "logging"]
 
 [badges]
-github = { repository = "NAlexPear/tracing-stackdriver" } 
+github = { repository = "NAlexPear/tracing-stackdriver" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
@@ -21,6 +21,8 @@ tracing-core = "0.1.10"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
 tracing-serde = "0.1"
+thiserror = "1.0.26"
+
 
 [dependencies.chrono]
 features = ["serde"]


### PR DESCRIPTION
Note that if you're on GCP + Docker, it also requires forwarding through fluentd to work.  The container gets started like this: `docker run --log-driver=fluentd --log-opt fluentd-address=127.0.0.1:24224 --log-opt tag=docker.SERVICE_NAME ...` and the fluentd config file (`/etc/google-fluentd/config.d/docker.conf` in my case) looks like this:

```
<source>
  @type forward
  port 24224
  bind 127.0.0.1
</source>

<filter docker.*>
  @type parser
  key_name "log"
  reserve_data true
  remove_key_name_field true
  <parse>
    @type json
   time_key time
   time_format %iso8601
  </parse>
</filter>

<match docker.*>
  @type google_cloud
  <buffer>
    flush_mode immediate
    retry_type exponential_backoff
  </buffer>
</match>
```