### PR TITLE
support outputing trace ID and span ID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ thiserror = "1.0.31"
 optional = true
 version = "0.2.8"
 
+[dependencies.opentelemetry]
+version = "0.17.0"
+optional = true
+
 [dependencies.url]
 optional = true
 version = "2.2.2"
@@ -41,6 +45,10 @@ version = "1.0.140"
 default-features = false
 features = ["formatting"]
 version = "0.3.11"
+
+[dependencies.tracing-opentelemetry]
+version = "0.17.4"
+optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
@@ -65,3 +73,8 @@ version = "0.3.11"
 
 [features]
 valuable = ["dep:valuable", "valuable-serde", "http", "url"]
+
+opentelemetry = [
+    "dep:opentelemetry",
+    "tracing-opentelemetry"
+]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This crate provides a [`Layer`](https://docs.rs/tracing-subscriber/0.2.4/tracing
 5. automatic nesting of `http_request.`-prefixed event fields
 6. automatic camelCase-ing of all field keys (e.g. `http_request` -> `httpRequest`)
 7. [`valuable`](https://docs.rs/valuable/latest/valuable/) support, including an `HttpRequest` helper `struct`
+8. [OpenTelemetry](https://opentelemetry.io) integration
 
 ### Examples
 
@@ -151,6 +152,24 @@ fn handle_request(request: Request) {
   //   "message": "Request received"
   // }
 }
+```
+
+#### With OpenTelemetry integration:
+
+`tracing_stackdriver` supports integration with [OpenTelemetry](https://opentelemetry.io) via [tracing_opentelemetry](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry) and outputs [special Cloud Logging fields](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields) for trace sampling and log correlation.
+
+To enable OpenTelemetry integration, you need to
+1. use the `opentelemetry` feature flag, and
+2. provide `StackdriverLayer` with your GCP project ID, and
+3. add a [tracing_opentelemetry](https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry) layer to the subscriber.
+```rust
+let stackdriver = tracing_stackdriver::layer()
+    .with_project_id("my_gcp_project_id".into());
+let subscriber = tracing_subscriber::Registry::default()
+    // You may want to configure the `tracing_opentelemetry` layer to suit your needs.
+    // See `tracing_opentelemetry`'s doc for details.
+    .with(tracing_opentelemetry::layer())
+    .with(stackdriver);
 ```
 
 #### Roadmap:

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,25 @@
+use std::{
+    io,
+    sync::{Mutex, TryLockError},
+};
+
+pub struct MockWriter<'a>(pub &'a Mutex<Vec<u8>>);
+
+impl<'a> MockWriter<'a> {
+    pub fn map_err<G>(error: TryLockError<G>) -> io::Error {
+        match error {
+            TryLockError::WouldBlock => io::Error::from(io::ErrorKind::WouldBlock),
+            TryLockError::Poisoned(_) => io::Error::from(io::ErrorKind::Other),
+        }
+    }
+}
+
+impl<'a> io::Write for MockWriter<'a> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0.try_lock().map_err(Self::map_err)?.write(buffer)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.try_lock().map_err(Self::map_err)?.flush()
+    }
+}

--- a/tests/opentelemetry.rs
+++ b/tests/opentelemetry.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "opentelemetry")]
+
+use lazy_static::lazy_static;
+use serde::Deserialize;
+use std::{fmt::Debug, sync::Mutex};
+use tracing_subscriber::layer::SubscriberExt;
+
+mod common;
+
+macro_rules! run_with_tracing {
+    (|| $expression:expr) => {{
+        lazy_static! {
+            static ref BUFFER: Mutex<Vec<u8>> = Mutex::new(vec![]);
+        }
+
+        let make_writer = || crate::common::MockWriter(&BUFFER);
+        let stackdriver = tracing_stackdriver::layer()
+            .with_writer(make_writer)
+            .with_project_id("my_project_123".into());
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(tracing_opentelemetry::layer())
+            .with(stackdriver);
+
+        tracing::subscriber::with_default(subscriber, || $expression);
+
+        &BUFFER
+            .try_lock()
+            .expect("Couldn't get lock on test write target")
+            .to_vec()
+    }};
+}
+
+#[derive(Debug, Deserialize)]
+struct MockEventWithCloudTraceFields {
+    #[serde(rename = "logging.googleapis.com/spanId")]
+    span_id: Option<String>,
+    #[serde(rename = "logging.googleapis.com/trace")]
+    trace_id: Option<String>,
+    #[serde(rename = "logging.googleapis.com/trace_sampled")]
+    trace_sampled: Option<bool>,
+}
+
+#[test]
+fn includes_cloud_trace_fields() {
+    use opentelemetry::trace::{
+        SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    };
+
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    let output = run_with_tracing!(|| {
+        let cx = opentelemetry::Context::new().with_remote_span_context(SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::SAMPLED,
+            true,
+            TraceState::from_key_value([("", ""); 0]).unwrap(),
+        ));
+        let root_span = tracing::info_span!("root_span");
+        root_span.set_parent(cx);
+        root_span.in_scope(|| {
+            tracing::info!("Should have cloud trace fields");
+        });
+    });
+
+    let output = serde_json::from_slice::<MockEventWithCloudTraceFields>(output)
+        .expect("Error converting test buffer to JSON");
+
+    assert!(matches!(
+        output.span_id.as_deref().map(SpanId::from_hex),
+        Some(Ok(_))
+    ));
+    assert_eq!(
+        output.trace_id.as_deref(),
+        Some("projects/my_project_123/traces/0af7651916cd43dd8448eb211c80319c")
+    );
+    assert_eq!(output.trace_sampled, Some(true))
+}
+
+#[test]
+fn includes_cloud_trace_fields_in_nested_span() {
+    use opentelemetry::trace::{
+        SpanContext, SpanId, TraceContextExt, TraceFlags, TraceId, TraceState,
+    };
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let output = run_with_tracing!(|| {
+        let cx = opentelemetry::Context::new().with_remote_span_context(SpanContext::new(
+            TraceId::from_hex("0af7651916cd43dd8448eb211c80319c").unwrap(),
+            SpanId::from_hex("b7ad6b7169203331").unwrap(),
+            TraceFlags::default(),
+            true,
+            TraceState::from_key_value([("", ""); 0]).unwrap(),
+        ));
+        let root_span = tracing::info_span!("root_span");
+        root_span.set_parent(cx);
+        root_span.in_scope(|| {
+            let inner_span = tracing::info_span!("inner_span");
+            inner_span.in_scope(|| {
+                tracing::info!("Should have cloud trace fields");
+            });
+        })
+    });
+
+    let output = serde_json::from_slice::<MockEventWithCloudTraceFields>(output)
+        .expect("Error converting test buffer to JSON");
+
+    assert!(matches!(
+        output.span_id.as_deref().map(SpanId::from_hex),
+        Some(Ok(_))
+    ));
+    assert_eq!(
+        output.trace_id.as_deref(),
+        Some("projects/my_project_123/traces/0af7651916cd43dd8448eb211c80319c")
+    );
+    assert!(!matches!(output.trace_sampled, Some(true)))
+}


### PR DESCRIPTION
This is inspired by the other CL #6 but does things a bit differently.

1. Takes trace ID from parent_cx when trace ID is not found in the current span.
   - to ensure trace ID is populated correctly in nested spans.
3. Add "projects/{project_id}/traces/" prefix to the output
   - so we don't need to rely on [autoformat_stackdriver_trace](https://cloud.google.com/logging/docs/agent/logging/configuration#cloud-fluentd-config)
   - in some environments (e.g. cloud run), we can't modify the logging agent to support autoformat_stackdriver_trace
3. Require users to specify project ID when calling Stackdriver::layer

If you are happy with the API change, I'll add some unit tests.