### PR TITLE
chore: relax dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "~0.1.22"
+tracing-core = "0.1.22"
 thiserror = "1.0.31"
 
 [dependencies.http]
@@ -47,12 +47,12 @@ features = ["formatting"]
 version = "0.3.11"
 
 [dependencies.tracing-opentelemetry]
-version = "0.17"
+version = "0.17.4"
 optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3"
+version = "0.3.15"
 
 [dependencies.valuable]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1"
+tracing = "0.1.35"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "0.1"
+tracing-core = "~0.1.22"
 thiserror = "1.0.31"
 
 [dependencies.http]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3.15"
+version = "0.3.11"
 
 [dependencies.valuable]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1.35"
+tracing = "0.1.34"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "0.1.28"
+tracing-core = "0.1"
 thiserror = "1.0.31"
 
 [dependencies.http]
@@ -47,12 +47,12 @@ features = ["formatting"]
 version = "0.3.11"
 
 [dependencies.tracing-opentelemetry]
-version = "0.17.4"
+version = "0.17"
 optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3.15"
+version = "0.3"
 
 [dependencies.valuable]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1.35"
+tracing = "0.1"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]


### PR DESCRIPTION
Hi! 👋🏻 

We're using a different version of the `tracing-core` crate, which causes issues when we try to add this crate to our project, as the exact version are incompatible. I've tried to relax the tracing crates version requirements and was able to get this working without any problem.

Would it be possible to relax the version here so we don't have to depend on our own fork on this crate?