### PR TITLE
Update tracing dependencies to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "0.1.28"
+tracing-core = "0.1"
 thiserror = "1.0.31"
 
 [dependencies.http]
@@ -43,12 +43,12 @@ features = ["formatting"]
 version = "0.3.11"
 
 [dependencies.tracing-opentelemetry]
-version = "0.17.4"
+version = "0.17"
 optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3.15"
+version = "0.3"
 
 [dependencies.url]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1.35"
+tracing = "0.1"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3.15"
+version = "0.3.11"
 
 [dependencies.url]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1.35"
+tracing = "0.1.34"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "~0.1.22"
+tracing-core = "0.1.22"
 thiserror = "1.0.31"
 
 [dependencies.http]
@@ -43,12 +43,12 @@ features = ["formatting"]
 version = "0.3.11"
 
 [dependencies.tracing-opentelemetry]
-version = "0.17"
+version = "0.17.4"
 optional = true
 
 [dependencies.tracing-subscriber]
 features = ["json"]
-version = "0.3"
+version = "0.3.15"
 
 [dependencies.url]
 optional = true
@@ -65,7 +65,7 @@ version = "0.1.0"
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-tracing = "0.1"
+tracing = "0.1.35"
 
 [dev-dependencies.time]
 features = ["serde", "serde-well-known", "formatting"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 Inflector = "0.11.4"
 serde_json = "1.0.82"
-tracing-core = "0.1"
+tracing-core = "~0.1.22"
 thiserror = "1.0.31"
 
 [dependencies.http]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ optional = true
 version = "0.2.8"
 
 [dependencies.opentelemetry]
-version = "0.17.0"
+version = "0.18.0"
 optional = true
 
 [dependencies.serde]
@@ -43,7 +43,7 @@ features = ["formatting"]
 version = "0.3.11"
 
 [dependencies.tracing-opentelemetry]
-version = "0.17.4"
+version = "0.18"
 optional = true
 
 [dependencies.tracing-subscriber]


### PR DESCRIPTION
Updated opentelemetry and tracing-opentelemetry dependencies to 0.18.x. I've been testing this for the last few weeks and it works fine. 
Also wondering why you haven't release the opentelemetry integration officially since it also seems to work fine with Cloud Trace. 