### PR TITLE
Add structured logging of the source location

### DIFF
--- a/src/event_formatter.rs
+++ b/src/event_formatter.rs
@@ -1,6 +1,6 @@
 use crate::{
     google::LogSeverity,
-    serializers::{SerializableContext, SerializableSpan},
+    serializers::{SerializableContext, SerializableSpan, SourceLocation},
     visitor::Visitor,
     writer::WriteAdaptor,
 };
@@ -68,6 +68,16 @@ impl EventFormatter {
         // serialize custom fields
         map.serialize_entry("time", &time)?;
         map.serialize_entry("target", &meta.target())?;
+
+        if let Some(file) = meta.file() {
+            map.serialize_entry(
+                "logging.googleapis.com/sourceLocation",
+                &SourceLocation {
+                    file,
+                    line: meta.line(),
+                },
+            )?;
+        }
 
         // serialize the current span and its leaves
         if let Some(span) = span {

--- a/src/serializers.rs
+++ b/src/serializers.rs
@@ -89,3 +89,24 @@ where
         list.end()
     }
 }
+
+pub(crate) struct SourceLocation<'a> {
+    pub(crate) file: &'a str,
+    pub(crate) line: Option<u32>,
+}
+
+impl<'a> Serialize for SourceLocation<'a> {
+    fn serialize<R>(&self, serializer: R) -> Result<R::Ok, R::Error>
+    where
+        R: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(if self.line.is_some() { 2 } else { 1 }))?;
+        map.serialize_entry("file", self.file)?;
+        if let Some(line) = self.line {
+            // Stackdriver expects the line number to be serialised as a string:
+            // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
+            map.serialize_entry("line", &line.to_string())?;
+        }
+        map.end()
+    }
+}

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -128,3 +128,13 @@ fn nests_http_request() {
 
     assert_eq!(&output.http_request, &mock_http_request);
 }
+
+#[test]
+fn includes_source_location() {
+    let output =
+        serde_json::from_slice::<MockDefaultEvent>(run_with_tracing!(|| tracing::info!("hello!")))
+            .expect("Error converting test buffer to JSON");
+    assert!(output.source_location.file.ends_with("default.rs"));
+    assert!(!output.source_location.line.is_empty());
+    assert!(output.source_location.line != "0");
+}

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -1,12 +1,20 @@
 use serde::Deserialize;
 use time::OffsetDateTime;
 
+#[derive(Clone, Debug, Deserialize)]
+pub struct MockSourceLocation {
+    pub file: String,
+    pub line: String,
+}
+
 #[derive(Clone, Deserialize)]
 pub struct MockDefaultEvent {
     #[serde(deserialize_with = "time::serde::rfc3339::deserialize")]
     pub time: OffsetDateTime,
     pub target: String,
     pub severity: String,
+    #[serde(rename = "logging.googleapis.com/sourceLocation")]
+    pub source_location: MockSourceLocation,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This follows the format at https://cloud.google.com/logging/docs/structured-logging and specifically https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation

This doesn't log the function name, as tracing doesn't appear to provide any way of finding out the name of the enclosing function at the moment. If you look at https://docs.rs/tracing/latest/tracing/struct.Metadata.html you can extract the module path, but nothing appears to give the name of the function.

Thank you for the very useful crate!