### PR TITLE
Add structured logging of insert id, labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,34 @@ fn main() {
     // }
 }
 ```
+
+#### With Cloud Fields support:
+
+Don't want to use Cloud Trace using OpenTelemetry? No problem, `tracing_stackdriver` has the possiblility.
+
+`tracing_stackdriver` supports [special Cloud Trace `LogEntry` fields](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields), without using OpenTelemetry.
+
+```rust
+fn main() {
+    // requires working global setup (see above examples)
+    tracing::info!(
+        google.insert_id = "test",
+        google.labels.app = "some-app",
+        google.labels.version = "first",
+        google.labels.version = "last",
+        "With a message."
+    );
+
+    // Json Payload
+    // {
+    //    "time": "some-timestamp",
+    //    "severity": "INFO",
+    //    "logging.googleapis.com/insertId": "test",
+    //    "message": "With a message.",
+    //    "logging.googleapis.com/labels": {
+    //       "app": "some-app",
+    //       "version":"last"
+    //    }
+    // }
+}
+```

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::disallowed_names)]
+use std::collections::BTreeMap;
 use lazy_static::lazy_static;
-use mocks::{MockDefaultEvent, MockEventWithSpan, MockHttpEvent, MockHttpRequest};
+use mocks::{MockDefaultEvent, MockEventWithSpan, MockHttpEvent, MockHttpRequest, MockGoogleLabelsEvent, MockGoogleFieldsEvent};
 use serde::Deserialize;
 use std::sync::Mutex;
 use time::OffsetDateTime;
@@ -127,6 +128,29 @@ fn nests_http_request() {
     .expect("Error converting test buffer to JSON");
 
     assert_eq!(&output.http_request, &mock_http_request);
+}
+
+#[test]
+fn nests_google_labels() {
+    let mut mock = BTreeMap::<String, String>::new();
+    mock.insert("app".parse().unwrap(), "test".parse().unwrap());
+
+    let output = serde_json::from_slice::<MockGoogleLabelsEvent>(run_with_tracing!(|| tracing::info!(
+        google.labels.app = "test",
+    )))
+        .expect("Error converting test buffer to JSON");
+
+    assert_eq!(&output.google_labels, &mock);
+}
+
+#[test]
+fn nests_google_insert_id() {
+    let output = serde_json::from_slice::<MockGoogleFieldsEvent>(run_with_tracing!(|| tracing::info!(
+        google.insert_id = "test",
+    )))
+        .expect("Error converting test buffer to JSON");
+
+    assert_eq!(&output.insert_id, "test");
 }
 
 #[test]

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -41,4 +42,18 @@ pub struct MockHttpRequest {
 #[serde(rename_all = "camelCase")]
 pub struct MockHttpEvent {
     pub http_request: MockHttpRequest,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MockGoogleLabelsEvent {
+    #[serde(rename = "logging.googleapis.com/labels")]
+    pub google_labels: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MockGoogleFieldsEvent {
+    #[serde(rename = "logging.googleapis.com/insertId")]
+    pub insert_id: String,
 }


### PR DESCRIPTION
This enables the `logging.googleapis.com/` prefix for logs that are mentioned here: https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields.

It also enables adding labels.

Thank you for the very useful crate!