### PR TITLE
Adds builder pattern to configure cloud tracing and line numbers settings

### DIFF
--- a/src/event_formatter.rs
+++ b/src/event_formatter.rs
@@ -40,6 +40,8 @@ impl From<Error> for fmt::Error {
 pub struct EventFormatter {
     #[cfg(feature = "opentelemetry")]
     pub(crate) cloud_trace_configuration: Option<crate::CloudTraceConfiguration>,
+
+    pub(crate) source_location_enabled: crate::SourceLocationConfiguration,
 }
 
 impl EventFormatter {
@@ -69,14 +71,16 @@ impl EventFormatter {
         map.serialize_entry("time", &time)?;
         map.serialize_entry("target", &meta.target())?;
 
-        if let Some(file) = meta.file() {
-            map.serialize_entry(
-                "logging.googleapis.com/sourceLocation",
-                &SourceLocation {
-                    file,
-                    line: meta.line(),
-                },
-            )?;
+        if self.source_location_enabled == crate::SourceLocationConfiguration::Enabled {
+            if let Some(file) = meta.file() {
+                map.serialize_entry(
+                    "logging.googleapis.com/sourceLocation",
+                    &SourceLocation {
+                        file,
+                        line: meta.line(),
+                    },
+                )?;
+            }
         }
 
         // serialize the current span and its leaves

--- a/src/google.rs
+++ b/src/google.rs
@@ -231,6 +231,40 @@ impl valuable::Structable for HttpRequest {
     }
 }
 
+/// Configuration builder for the layer formatter.
+#[derive(Clone, Default)]
+pub struct Configuration {
+    #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+    #[cfg(any(docsrs, feature = "opentelemetry"))]
+    pub(crate) cloud_trace_configuration: Option<CloudTraceConfiguration>,
+
+    pub(crate) source_location_configuration: SourceLocationConfiguration,
+}
+
+impl Configuration {
+    /// Enable Cloud Trace integration with OpenTelemetry through special LogEntry fields
+    #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+    #[cfg(any(docsrs, feature = "opentelemetry"))]
+    pub fn enable_cloud_trace(self, project_id: String) -> Self {
+        Self {
+            #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+            #[cfg(any(docsrs, feature = "opentelemetry"))]
+            cloud_trace_configuration: Some(CloudTraceConfiguration { project_id }),
+            source_location_configuration,
+        }
+    }
+
+    /// Enable source location fields through special LogEntry fields
+    pub fn enable_source_location(self) -> Self {
+        Self {
+            #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+            #[cfg(any(docsrs, feature = "opentelemetry"))]
+            cloud_trace_configuration,
+            source_location_configuration: SourceLocationConfiguration::Enabled,
+        }
+    }
+}
+
 /// Configuration for projects looking to use the [Cloud Trace](https://cloud.google.com/trace) integration
 /// through [trace-specific fields](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace) in
 /// a LogEntry.
@@ -242,4 +276,21 @@ pub struct CloudTraceConfiguration {
     /// ID](https://cloud.google.com/resource-manager/docs/creating-managing-projects) for
     /// prefixing and identifying collectecd traces.
     pub project_id: String,
+}
+
+/// Configures whether to write the optional source location field.
+/// When enabled adds `logging.googleapis.com/sourceLocation{file: "src/lib.rs", line: "210"}`
+/// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogEntrySourceLocation
+#[derive(Clone, PartialEq)]
+pub enum SourceLocationConfiguration {
+    /// Enable source location information. Adds `logging.googleapis.com/sourceLocation{file: "src/lib.rs", line: "210"}`
+    Enabled,
+    /// Disable source location information
+    Disabled,
+}
+
+impl Default for SourceLocationConfiguration {
+    fn default() -> Self {
+        SourceLocationConfiguration::Disabled
+    }
 }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -58,12 +58,14 @@ where
         Layer(self.0.with_writer(make_writer))
     }
 
-    /// Enable Cloud Trace integration with OpenTelemetry through special LogEntry fields
-    #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
-    #[cfg(any(docsrs, feature = "opentelemetry"))]
-    pub fn enable_cloud_trace(self, configuration: crate::CloudTraceConfiguration) -> Self {
+    /// Add optional settings to stackdriver layer
+    pub fn with_settings(self, configuration: crate::Configuration) -> Self {
         Self(self.0.event_format(EventFormatter {
-            cloud_trace_configuration: Some(configuration),
+            #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
+            #[cfg(any(docsrs, feature = "opentelemetry"))]
+            cloud_trace_configuration: configuration.cloud_trace_configuration,
+
+            source_location_enabled: configuration.source_location_configuration,
         }))
     }
 }

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -7,6 +7,8 @@ use time::OffsetDateTime;
 use tracing_stackdriver::LogSeverity;
 use tracing_subscriber::{layer::SubscriberExt, Registry};
 
+use crate::mocks::MockDefaultEventWithSourceLocation;
+
 mod helpers;
 mod mocks;
 mod writer;
@@ -131,9 +133,10 @@ fn nests_http_request() {
 
 #[test]
 fn includes_source_location() {
-    let output =
-        serde_json::from_slice::<MockDefaultEvent>(run_with_tracing!(|| tracing::info!("hello!")))
-            .expect("Error converting test buffer to JSON");
+    let output = serde_json::from_slice::<MockDefaultEventWithSourceLocation>(
+        run_with_tracing_source_location!(|| tracing::info!("hello!")),
+    )
+    .expect("Error converting test buffer to JSON");
     assert!(output.source_location.file.ends_with("default.rs"));
     assert!(!output.source_location.line.is_empty());
     assert!(output.source_location.line != "0");

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,13 +1,35 @@
 // FIXME: make this a simple function instead
 #[macro_export]
 macro_rules! run_with_tracing {
-    (|| $expression:expr) => {{
+    (|| $expression:expr ) => {{
         lazy_static! {
             static ref BUFFER: Mutex<Vec<u8>> = Mutex::new(vec![]);
         }
 
         let make_writer = || writer::MockWriter(&BUFFER);
         let stackdriver = tracing_stackdriver::layer().with_writer(make_writer);
+        let subscriber = Registry::default().with(stackdriver);
+
+        tracing::subscriber::with_default(subscriber, || $expression);
+
+        &BUFFER
+            .try_lock()
+            .expect("Couldn't get lock on test write target")
+            .to_vec()
+    }};
+}
+
+#[macro_export]
+macro_rules! run_with_tracing_source_location {
+    (|| $expression:expr ) => {{
+        lazy_static! {
+            static ref BUFFER: Mutex<Vec<u8>> = Mutex::new(vec![]);
+        }
+
+        let make_writer = || writer::MockWriter(&BUFFER);
+        let stackdriver = tracing_stackdriver::layer()
+            .with_settings(tracing_stackdriver::Configuration::default().enable_source_location())
+            .with_writer(make_writer);
         let subscriber = Registry::default().with(stackdriver);
 
         tracing::subscriber::with_default(subscriber, || $expression);

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -13,6 +13,14 @@ pub struct MockDefaultEvent {
     pub time: OffsetDateTime,
     pub target: String,
     pub severity: String,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct MockDefaultEventWithSourceLocation {
+    #[serde(deserialize_with = "time::serde::rfc3339::deserialize")]
+    pub time: OffsetDateTime,
+    pub target: String,
+    pub severity: String,
     #[serde(rename = "logging.googleapis.com/sourceLocation")]
     pub source_location: MockSourceLocation,
 }


### PR DESCRIPTION
Hello! Thanks for making and taking care of this crate!

When upgrading to the latest version, we found that the source location line numbers which got added were too noisy for the value they provided for us. 

This PR adds a builder struct to configure the stackdriver layer. I tried implementing it like `enable_cloud_trace`, but I ran into issues accessing variables in `self`. Maybe there is some more idiomatic way to accomplish this?

What I tried but could not get to work was something like this:

```
    /// Enable Cloud Trace integration with OpenTelemetry through special LogEntry fields
    #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
    #[cfg(any(docsrs, feature = "opentelemetry"))]
    pub fn enable_cloud_trace(self, configuration: crate::CloudTraceConfiguration) -> Self {
        Self(self.0.event_format(EventFormatter {
            cloud_trace_configuration: Some(configuration),
            source_location_enabled: ?????, // <--- The already existing setting.
        }))
    }

    pub fn enable_cloud_trace(self, configuration: crate::CloudTraceConfiguration) -> Self {
    /// Add optional settings to stackdriver layer
    pub fn enable_line_numbers(self) -> Self {
        Self(self.0.event_format(EventFormatter {
            cloud_trace_configuration: ?????, // <--- The already existing setting.
            source_location_enabled: true,
        }))
    }
```

I also made a duplicate of the test macro for tests with and without line numbers since I did not want to further complicate the macro.

If you prefer some other method to implement this, maybe a feature flag, I will update the PR :) 

/Mathias