### PR TITLE
Implement label and insert ID mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ This crate provides a [`Layer`](https://docs.rs/tracing-subscriber/0.2.4/tracing
 3. `target` derived from the Event `target` [`Metadata`](https://docs.rs/tracing/0.1.13/tracing/struct.Metadata.html)
 4. Span `name` and custom fields included under a `span` key
 5. automatic nesting of `http_request.`-prefixed event fields
-6. automatic camelCase-ing of all field keys (e.g. `http_request` -> `httpRequest`)
-7. [`valuable`](https://docs.rs/valuable/latest/valuable/) support, including an `HttpRequest` helper `struct`
-8. [Cloud Trace](https://cloud.google.com/trace) support derived from [OpenTelemetry](https://opentelemetry.io) Span and [Trace IDs](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace).
+6. automatic nesting of `labels.`-prefixed event fields
+7. automatic camelCase-ing of all field keys (e.g. `http_request` -> `httpRequest`)
+8. [`valuable`](https://docs.rs/valuable/latest/valuable/) support, including an `HttpRequest` helper `struct`
+9. [Cloud Trace](https://cloud.google.com/trace) support derived from [OpenTelemetry](https://opentelemetry.io) Span and [Trace IDs](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace).
 
 ### Examples
 
@@ -71,6 +72,34 @@ fn handle_request(request: Request) {
     //     "requestUrl": "/some/url/from/request"
     //    },
     //   "message": "Request received"
+    // }
+}
+```
+
+#### With `labels` fields:
+
+A key/value map of stringified labels mapped to the `logging.googleapis.com/labels` [special field](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields). More information about `labels` can be found [here](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.labels).
+
+```rust
+// requires working global setup (see above examples)
+
+fn main() {
+    tracing::info!(
+      labels.thread_count = 3,
+      labels.is_production = true,
+      labels.note = "A short note",
+      "Application starting"
+    );
+
+    // jsonPayload formatted as:
+    // {
+    //   "time": "some-timestamp"
+    //   "message": "Application starting",
+    //   "logging.googleapis.com/labels": {
+    //     "threadCount": "3",
+    //     "isProduction": "true",
+    //     "note": "A short note",
+    //   }
     // }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ This crate provides a [`Layer`](https://docs.rs/tracing-subscriber/0.2.4/tracing
 3. `target` derived from the Event `target` [`Metadata`](https://docs.rs/tracing/0.1.13/tracing/struct.Metadata.html)
 4. Span `name` and custom fields included under a `span` key
 5. automatic nesting of `http_request.`-prefixed event fields
-6. automatic nesting of `labels.`-prefixed event fields
-7. automatic camelCase-ing of all field keys (e.g. `http_request` -> `httpRequest`)
-8. [`valuable`](https://docs.rs/valuable/latest/valuable/) support, including an `HttpRequest` helper `struct`
-9. [Cloud Trace](https://cloud.google.com/trace) support derived from [OpenTelemetry](https://opentelemetry.io) Span and [Trace IDs](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace).
+6. automatic nesting of `labels.`-prefixed event fields, re-written as a [special field](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields).
+7. automatic re-writing of `insert_id`s as a [special field](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields).
+8. automatic camelCase-ing of all field keys (e.g. `http_request` -> `httpRequest`)
+9. [`valuable`](https://docs.rs/valuable/latest/valuable/) support, including an `HttpRequest` helper `struct`
+10. [Cloud Trace](https://cloud.google.com/trace) support derived from [OpenTelemetry](https://opentelemetry.io) Span and [Trace IDs](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.trace).
 
 ### Examples
 
@@ -100,6 +101,28 @@ fn main() {
     //     "isProduction": "true",
     //     "note": "A short note",
     //   }
+    // }
+}
+```
+
+#### With `insert_id` field:
+
+A stringified `insert_id` mapped to the `logging.googleapis.com/insertId` [special field](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields). More information about `insertId` can be found [here](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#FIELDS.insert_id). This is an optional field, as the Logging API assigns its own unique identifier to this field if `insert_id` is omitted.
+
+```rust
+// requires working global setup (see above examples)
+
+fn main() {
+    tracing::info!(
+      insert_id = 1234,
+      "Application starting"
+    );
+
+    // jsonPayload formatted as:
+    // {
+    //   "time": "some-timestamp"
+    //   "message": "Application starting",
+    //   "logging.googleapis.com/insertId": "1234"
     // }
 }
 ```

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -61,6 +61,15 @@ where
 
                         labels.insert(label_key.to_camel_case(), value);
                     }
+                    (Some("insert_id"), None) => {
+                        let value = match value {
+                            serde_json::Value::String(value) => value,
+                            _ => value.to_string(),
+                        };
+
+                        self.serializer
+                            .serialize_entry("logging.googleapis.com/insertId", &value)?;
+                    }
                     (Some(key), None) => self
                         .serializer
                         .serialize_entry(&key.to_camel_case(), &value)?,

--- a/tests/default.rs
+++ b/tests/default.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::disallowed_names)]
 use helpers::run_with_tracing;
-use mocks::{MockDefaultEvent, MockEventWithSpan, MockHttpEvent, MockHttpRequest};
+use mocks::{MockDefaultEvent, MockEventWithSpan};
 use serde::Deserialize;
 use time::OffsetDateTime;
 use tracing_stackdriver::LogSeverity;
@@ -95,33 +95,4 @@ fn includes_flattened_fields() {
     let event = events.first().expect("No event heard");
     assert_eq!(event.baz, baz);
     assert_eq!(event.message, "some stackdriver message");
-}
-
-#[test]
-fn nests_http_request() {
-    let request_method = "GET";
-    let latency = "0.23s";
-    let remote_ip = "192.168.1.1";
-    let status = 200;
-
-    let mock_http_request = MockHttpRequest {
-        request_method: request_method.to_string(),
-        latency: latency.to_string(),
-        remote_ip: remote_ip.to_string(),
-        status,
-    };
-
-    let events = run_with_tracing::<MockHttpEvent>(|| {
-        tracing::info!(
-            http_request.request_method = &request_method,
-            http_request.latency = &latency,
-            http_request.remote_ip = &remote_ip,
-            http_request.status = &status,
-            "some stackdriver message"
-        )
-    })
-    .expect("Error converting test buffer to JSON");
-
-    let event = events.first().expect("No event heard");
-    assert_eq!(event.http_request, mock_http_request);
 }

--- a/tests/http_request.rs
+++ b/tests/http_request.rs
@@ -1,0 +1,34 @@
+use helpers::run_with_tracing;
+use mocks::{MockHttpEvent, MockHttpRequest};
+
+mod helpers;
+mod mocks;
+
+#[test]
+fn nests_http_request() {
+    let request_method = "GET";
+    let latency = "0.23s";
+    let remote_ip = "192.168.1.1";
+    let status = 200;
+
+    let mock_http_request = MockHttpRequest {
+        request_method: request_method.to_string(),
+        latency: latency.to_string(),
+        remote_ip: remote_ip.to_string(),
+        status,
+    };
+
+    let events = run_with_tracing::<MockHttpEvent>(|| {
+        tracing::info!(
+            http_request.request_method = &request_method,
+            http_request.latency = &latency,
+            http_request.remote_ip = &remote_ip,
+            http_request.status = &status,
+            "some stackdriver message"
+        )
+    })
+    .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert_eq!(event.http_request, mock_http_request);
+}

--- a/tests/insert_id.rs
+++ b/tests/insert_id.rs
@@ -1,0 +1,38 @@
+use helpers::run_with_tracing;
+use mocks::MockDefaultEvent;
+
+mod helpers;
+mod mocks;
+
+#[test]
+fn includes_custom_insert_ids() {
+    let insert_id = "my-new-event".to_string();
+    let events =
+        run_with_tracing::<MockDefaultEvent>(|| tracing::info!(insert_id = insert_id, "hello!"))
+            .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert!(event.insert_id.is_some());
+    assert_eq!(event.insert_id, Some(insert_id));
+}
+
+#[test]
+fn stringifies_primitive_insert_id_values() {
+    let insert_id = 123;
+    let events =
+        run_with_tracing::<MockDefaultEvent>(|| tracing::info!(insert_id = insert_id, "hello!"))
+            .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert!(event.insert_id.is_some());
+    assert_eq!(event.insert_id, Some(insert_id.to_string()));
+}
+
+#[test]
+fn omits_insert_id_by_default() {
+    let events = run_with_tracing::<MockDefaultEvent>(|| tracing::info!("hello!"))
+        .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert!(event.insert_id.is_none());
+}

--- a/tests/labels.rs
+++ b/tests/labels.rs
@@ -1,0 +1,58 @@
+use helpers::run_with_tracing;
+use mocks::MockDefaultEvent;
+use std::collections::BTreeMap;
+
+mod helpers;
+mod mocks;
+
+#[test]
+fn nests_labels() {
+    let mut labels = BTreeMap::new();
+    labels.insert("foo", "bar".to_string());
+    labels.insert("baz", "luhrmann".to_string());
+
+    let events = run_with_tracing::<MockDefaultEvent>(|| {
+        tracing::info!(
+            labels.foo = labels.get("foo"),
+            labels.baz = labels.get("baz"),
+            "hello!"
+        )
+    })
+    .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert!(event.labels.get("foo").is_some());
+    assert_eq!(event.labels.get("foo"), labels.get("foo"));
+    assert!(event.labels.get("baz").is_some());
+    assert_eq!(event.labels.get("baz"), labels.get("baz"));
+}
+
+#[test]
+fn stringifies_primitive_label_values() {
+    let number = 2;
+    let boolean = false;
+    let string = "a short note";
+    let events = run_with_tracing::<MockDefaultEvent>(|| {
+        tracing::info!(
+            labels.number = number,
+            labels.boolean = boolean,
+            labels.string = string,
+            "hello!"
+        )
+    })
+    .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert_eq!(event.labels.get("number"), Some(&number.to_string()));
+    assert_eq!(event.labels.get("boolean"), Some(&boolean.to_string()));
+    assert_eq!(event.labels.get("string"), Some(&string.to_string()));
+}
+
+#[test]
+fn omits_labels_by_default() {
+    let events = run_with_tracing::<MockDefaultEvent>(|| tracing::info!("hello!"))
+        .expect("Error converting test buffer to JSON");
+
+    let event = events.first().expect("No event heard");
+    assert!(event.labels.is_empty());
+}

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use time::OffsetDateTime;
 
 #[derive(Clone, Debug, Deserialize)]
@@ -15,6 +16,8 @@ pub struct MockDefaultEvent {
     pub severity: String,
     #[serde(rename = "logging.googleapis.com/sourceLocation")]
     pub source_location: MockSourceLocation,
+    #[serde(rename = "logging.googleapis.com/labels", default)]
+    pub labels: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/mocks.rs
+++ b/tests/mocks.rs
@@ -18,6 +18,8 @@ pub struct MockDefaultEvent {
     pub source_location: MockSourceLocation,
     #[serde(rename = "logging.googleapis.com/labels", default)]
     pub labels: BTreeMap<String, String>,
+    #[serde(rename = "logging.googleapis.com/insertId", default)]
+    pub insert_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

This PR closes issue #14 in the spirit of PR #15 by mapping `insert_id` and `labels.*` fields to their respective `logging.googleapis.com` [special fields](https://cloud.google.com/logging/docs/agent/logging/configuration#special-fields).